### PR TITLE
Set default port to 5001 and disable debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,5 +90,5 @@ def ping() -> object:
 
 
 if __name__ == "__main__":
-    port = int(os.environ.get("PORT", "5000"))
-    app.run(debug=True, port=port)
+    port = int(os.environ.get("PORT", "5001"))
+    app.run(debug=False, port=port)


### PR DESCRIPTION
## Summary
- update the Flask app to default to port 5001
- disable debug mode when launching the application

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e86b8243d08325b2b38824881fcbb3